### PR TITLE
增加version参数以用于清除多语言文件的缓存

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -115,7 +115,8 @@ MultiLang.prototype.ajaxGet = function (requestUrl, callback) {
 }
 MultiLang.prototype.loadLangContent = function (fileName) {
     var that = this
-    this.ajaxGet(this.initArguments.path + fileName, function (data) {
+    var url = this.initArguments.version ? (this.initArguments.path + fileName + this.initArguments.version) : (this.initArguments.path + fileName) 
+    this.ajaxGet(url, function (data) {
         var jsondata = that.initArguments.dataType === 'txt' ? data : JSON.parse(data)
         that.initArguments.callback.call(that, jsondata, that.appLang)
     })

--- a/lib/index.js
+++ b/lib/index.js
@@ -115,7 +115,7 @@ MultiLang.prototype.ajaxGet = function (requestUrl, callback) {
 }
 MultiLang.prototype.loadLangContent = function (fileName) {
     var that = this
-    var url = this.initArguments.version ? (this.initArguments.path + fileName + this.initArguments.version) : (this.initArguments.path + fileName) 
+    var url = this.initArguments.version ? (this.initArguments.path + fileName + "?" + this.initArguments.version) : (this.initArguments.path + fileName) 
     this.ajaxGet(url, function (data) {
         var jsondata = that.initArguments.dataType === 'txt' ? data : JSON.parse(data)
         that.initArguments.callback.call(that, jsondata, that.appLang)


### PR DESCRIPTION
增加 参数version， 用于清除多语言文件的缓存，初始化时传入参数version，请求多语言文件时将会带上，如： version:555, 请求多语言文件时将会变成lang_tw.json?555